### PR TITLE
Use tabs by default for Go files

### DIFF
--- a/GoTools.sublime-settings
+++ b/GoTools.sublime-settings
@@ -15,7 +15,10 @@
   // Enable GoTools console debug output.
   "debug_enabled": false,
 
-  // Optional: Use GoTools for all *.go files.
+  // Use tabs for .go files
+  "translate_tabs_to_spaces": false,
+
+  // Use GoTools for all *.go files.
   "extensions":
   [
     "go"


### PR DESCRIPTION
As was the style at the time.
