### PR TITLE
Capture mouse events for goto definition

### DIFF
--- a/gotools_util.py
+++ b/gotools_util.py
@@ -23,6 +23,13 @@ class Buffers():
     offsets = Buffers.offset_at_cursor(view)
     return (view.file_name(), row, col, offsets[0], offsets[1])
 
+  @staticmethod
+  def location_for_event(view, event):
+    pt = view.window_to_text((event["x"], event["y"]))
+    row, col = view.rowcol(pt)
+    offset = view.text_point(row, col)
+    return (view.file_name(), row, col, offset)
+
 class GoBuffers():
   @staticmethod
   def func_name_at_cursor(view):


### PR DESCRIPTION
Convert go to definition to a TextCommand and support capturing mouse
events so users can click goto definition targets without having to
first position the text cursor on a symbol.

Fixes #35.