### PR TITLE
Fix over-eager matching using test at cursor

### DIFF
--- a/gotools_build.py
+++ b/gotools_build.py
@@ -106,7 +106,7 @@ class GotoolsBuildCommand(sublime_plugin.WindowCommand):
     cmd += packages
 
     for p in patterns:
-      cmd += ["-run", p]
+      cmd += ["-run", "^"+p+"$"]
 
     exec_opts["cmd"] = cmd
 


### PR DESCRIPTION
Prevent over-eager matching when using test at cursor by supplying
regex anchors to the function name passed to go test.

Fixes #47.