### PR TITLE
Hide popups on Windows

### DIFF
--- a/gotools_settings.py
+++ b/gotools_settings.py
@@ -88,10 +88,16 @@ def load_goenv():
   if not gobinary:
     raise Exception("GoTools: couldn't find the go binary in PATH: " + ospath)
 
+  # Hide popups on Windows
+  si = None
+  if platform.system() == "Windows":
+    si = subprocess.STARTUPINFO()
+    si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
   # Gather up the Go environment using `go env`.
   print("GoTools: initializing using Go binary: " + gobinary)
   goenv = {}
-  stdout, stderr = subprocess.Popen([gobinary, 'env'], stdout=subprocess.PIPE).communicate()
+  stdout, stderr = subprocess.Popen([gobinary, 'env'], stdout=subprocess.PIPE, startupinfo=si).communicate()
   if stderr and len(stderr) > 0:
     raise Exception("GoTools: '" + gobinary + " env' failed during initialization: " + stderr.decode())
   for env in stdout.decode().splitlines():

--- a/gotools_util.py
+++ b/gotools_util.py
@@ -97,9 +97,15 @@ class ToolRunner():
 
       env = os.environ.copy()
       env["GOPATH"] = self.settings.gopath
+
+      # Hide popups on Windows
+      si = None
+      if platform.system() == "Windows":
+        si = subprocess.STARTUPINFO()
+        si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
     
       start = time.time()
-      p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+      p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, startupinfo=si)
       stdout, stderr = p.communicate(input=stdin, timeout=timeout)
       p.wait(timeout=timeout)
       elapsed = round(time.time() - start)


### PR DESCRIPTION
Hi,

I have started using GoTools on Sublime Text 3 this morning.
I take the opportunity to thank you for this great integration of the Go tools!

On Windows, I noticed that console windows were popping up each time a go utility was called (two of them at runtime, one at each save for gofmt...) which was quite annoying.
After some investigation, I found out that they could be hidden through [an additional argument to Popen](https://docs.python.org/2/library/subprocess.html#subprocess.STARTUPINFO).

My only regret is to have this code duplicated at two locations: hopefully we can find a way to factor this out somewhere.

I hope this can be useful to other Windows users as well.