### PR TITLE
Use more intelligent environment variable resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ GoTools is a [Go programming language](http://www.golang.org) plugin for [Sublim
 * Autocompletion (using [gocode](https://github.com/nsf/gocode))
 * Build and test integration
 * Source analysis (using [oracle](https://godoc.org/golang.org/x/tools/oracle))
+* Identifier renaming (using [gorename](https://godoc.org/golang.org/x/tools/cmd/gorename))
 * Improved syntax support (borrowed from [GoSublime](https://github.com/DisposaBoy/GoSublime))
 
 ### Prerequisites

--- a/gotools_build.py
+++ b/gotools_build.py
@@ -29,6 +29,8 @@ class GotoolsBuildCommand(sublime_plugin.WindowCommand):
       file_regex = "^(.*\\.go):(\\d+):()(.*)$"
 
     env["GOPATH"] = self.settings.gopath
+    env["GOROOT"] = self.settings.goroot
+    env["PATH"] = self.settings.ospath
 
     exec_opts = {
       "cmd": cmd,
@@ -82,7 +84,8 @@ class GotoolsBuildCommand(sublime_plugin.WindowCommand):
 
     self.logger.log("running build for packages: " + str(build_packages))
 
-    exec_opts["cmd"] = ["go", "install"] + build_packages
+    go = GoToolsSettings.find_go_binary(self.settings.ospath)
+    exec_opts["cmd"] = [go, "install"] + build_packages
 
     self.window.run_command("exec", exec_opts)
 
@@ -92,7 +95,8 @@ class GotoolsBuildCommand(sublime_plugin.WindowCommand):
     self.logger.log("test packages: " + str(packages))
     self.logger.log("test patterns: " + str(patterns))
 
-    cmd = ["go", "test"]
+    go = GoToolsSettings.find_go_binary(self.settings.ospath)
+    cmd = [go, "test"]
 
     if len(tags) > 0:
       cmd += ["-tags", ",".join(tags)]

--- a/gotools_settings.py
+++ b/gotools_settings.py
@@ -3,6 +3,7 @@ import os
 import platform
 import re
 import subprocess
+import tempfile
 
 class MergedSettings():
   def __init__(self):
@@ -12,7 +13,12 @@ class MergedSettings():
     self.project = sublime.active_window().active_view().settings().get('GoTools', {})
 
   def get(self, key, default = None):
-    return self.project.get(key, self.plugin.get(key, default))
+    # Treat empty values as undefined. This is more convenient internally.
+    val = self.project.get(key, '')
+    if len(str(val)) > 0: return val
+    val = self.plugin.get(key, '')
+    if len(str(val)) > 0: return val
+    return default
 
 class GoToolsSettings():
   def __init__(self):
@@ -22,29 +28,30 @@ class GoToolsSettings():
     # Load the Sublime settings files.
     settings = MergedSettings()
 
-    self.goroot = self.GoEnv["GOROOT"]
+    # Project > Plugin > Shell env > OS env > go env
+    self.gopath = settings.get('gopath', self.GoEnv["GOPATH"])
+    self.goroot = settings.get('goroot', self.GoEnv["GOROOT"])
+    self.ospath = settings.get('path', self.GoEnv["PATH"])
+
     self.goarch = self.GoEnv["GOHOSTARCH"]
     self.goos = self.GoEnv["GOHOSTOS"]
     self.go_tools = self.GoEnv["GOTOOLDIR"]
-    self.ospath = self.GoEnv["OSPATH"]
 
     if not self.goroot or not self.goarch or not self.goos or not self.go_tools:
-      raise Exception("GoTools: ERROR: Couldn't detect Go runtime information from `go env`.")
+      raise Exception("GoTools couldn't find Go runtime information")
 
     # The GOROOT bin directory is namespaced with the GOOS and GOARCH.
     self.gorootbin = os.path.join(self.goroot, "bin", self.goos + "_" + self.goarch)
 
-    # For GOPATH, env < plugin < project, and project supports replacement of
-    # ${gopath} with whatever preceded in the hierarchy.
-    self.gopath = settings.plugin.get('gopath', os.getenv('GOPATH', ''))
-    if len(self.gopath) == 0:
-      self.gopath = self.GoEnv['GOPATH']
-
+    # Support 'gopath' expansion in project settings.
     if 'gopath' in settings.project:
-      self.gopath = settings.project['gopath'].replace('${gopath}', self.gopath)
-
+      sub = settings.plugin.get('gopath', '')
+      if len(sub) == 0:
+        sub = self.GoEnv['GOPATH']
+      self.gopath = settings.project['gopath'].replace('${gopath}', sub)
+    
     if self.gopath is None or len(self.gopath) == 0:
-      raise Exception("GoTools: ERROR: You must set either the `gopath` setting or the GOPATH environment variable.")
+      raise Exception("GoTools requires either the `gopath` setting or the GOPATH environment variable to be s")
 
     # Plugin feature settings.
     self.debug_enabled = settings.get("debug_enabled")
@@ -62,32 +69,27 @@ class GoToolsSettings():
     self.verbose_tests = settings.get("verbose_tests", False)
     self.test_timeout = settings.get("test_timeout", None)
 
-# For Go runtime information, verify go on PATH and ask it about itself.
-def load_goenv():
-  # Look up the system PATH.
-  ospath = os.getenv('PATH', '')
-  # For Darwin, get a login shell to resolve PATH as launchd won't always
-  # provide it. This technique is borrowed from SublimeFixMacPath[1].
-  # [1] https://github.com/int3h/SublimeFixMacPath.
-  if platform.system() == "Darwin":
-    command = "/usr/bin/login -fqpl $USER $SHELL -l -c 'printf \"%s\" \"$PATH\"'"
-    stdout, stderr = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True).communicate()
-    if stderr and len(stderr) > 0:
-      raise Exception("GoTools: couldn't resolve system PATH: " + stderr.decode())
-    ospath = stdout.decode()
+  @staticmethod
+  def find_go_binary(path=""):
+    goname = "go"
+    if platform.system() == "Windows":
+      goname = "go.exe"
+    for segment in path.split(os.pathsep):
+      candidate = os.path.join(segment, goname)
+      if os.path.isfile(candidate):
+        return candidate
+    raise Exception("couldn't find the go binary in path: {0}".format(path))
 
-  # Find the go binary on PATH, and abort initialization if it can't be found.
-  gobinary = None
-  goname = "go"
-  if platform.system() == "Windows":
-    goname = "go.exe"
-  for segment in ospath.split(os.pathsep):
-    candidate = os.path.join(segment, goname)
-    if os.path.isfile(candidate):
-      gobinary = candidate
-      break
-  if not gobinary:
-    raise Exception("GoTools: couldn't find the go binary in PATH: " + ospath)
+# Load PATH, GOPATH, GOROOT, and anything `go env` can provide. Use the
+# precedence order: Login shell > OS env > go env. All the values are stored
+# in GoToolsSettings.GoEnv.
+def load_goenv():
+  special_keys = ['PATH', 'GOPATH', 'GOROOT']
+  env = {}
+
+  # Gather up keys from the OS environment.
+  for k in special_keys:
+    env[k] = os.getenv(k, '')
 
   # Hide popups on Windows
   si = None
@@ -95,21 +97,56 @@ def load_goenv():
     si = subprocess.STARTUPINFO()
     si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
-  # Gather up the Go environment using `go env`.
-  print("GoTools: initializing using Go binary: " + gobinary)
-  goenv = {}
-  goenv["OSPATH"] = ospath
-  stdout, stderr = subprocess.Popen([gobinary, 'env'], stdout=subprocess.PIPE, startupinfo=si).communicate()
-  if stderr and len(stderr) > 0:
-    raise Exception("GoTools: '" + gobinary + " env' failed during initialization: " + stderr.decode())
-  for env in stdout.decode().splitlines():
-    match = re.match('(.*)=\"(.*)\"', env)
-    if platform.system() == "Windows":
-      match = re.match('(?:set\s)(.*)=(.*)', env)
-    if match and match.group(1) and match.group(2):
-      goenv[match.group(1)] = match.group(2)
-  return goenv
+  # For non-Windows platforms, use a login shell to get environment. Write the
+  # values to a tempfile; relying on stdout is brittle because of things like
+  # ANSI color codes which can come over stdout when .profile/.bashrc are
+  # sourced.
+  if platform.system() != "Windows":
+    for k in special_keys:
+      tempf = tempfile.NamedTemporaryFile()
+      cmd = [os.getenv("SHELL"), "-l", "-c", "sh -c -l 'echo ${0}>{1}'".format(k, tempf.name)]
+      try:
+        subprocess.check_output(cmd)
+        val = tempf.read().decode("utf-8").rstrip()
+        if len(val) > 0:
+          env[k] = val
+      except subprocess.CalledProcessError as e:
+        raise Exception("couldn't resolve environment variable '{0}': {1}".format(k, str(e)))
 
-# Load and keep a cache of the Go runtime information during plugin init.
-GoToolsSettings.GoEnv = load_goenv()
-print("GoTools: initialized with Go environment: "+str(GoToolsSettings.GoEnv))
+  if len(env['PATH']) == 0:
+    raise Exception("couldn't resolve PATH via system environment or login shell")
+
+  # Resolve the go binary.
+  gobinary = GoToolsSettings.find_go_binary(env['PATH'])
+
+  # Gather up the Go environment using `go env`, but only keep keys which
+  # aren't already set from the shell or OS environment.
+  cmdenv = os.environ.copy()
+  for k in env:
+    cmdenv[k] = env[k]
+  goenv, stderr = subprocess.Popen([gobinary, 'env'], 
+    stdout=subprocess.PIPE, stderr=subprocess.PIPE, startupinfo=si, env=cmdenv).communicate()
+  if stderr and len(stderr) > 0:
+    raise Exception("'{0} env' returned an error: {1}".format(gobinary, stderr.decode()))
+
+  for name in goenv.decode().splitlines():
+    match = re.match('(.*)=\"(.*)\"', name)
+    if platform.system() == "Windows":
+      match = re.match('(?:set\s)(.*)=(.*)', name)
+    if match and match.group(1) and match.group(2):
+      k = match.group(1)
+      v = match.group(2)
+      if not k in env or len(env[k]) == 0:
+        env[k] = v
+  return env
+
+# This is the plugin initialization, which loads required environment
+# variables. If this fails, the plugin is basically broken.
+#
+# TODO: find a better way to inform the user of problems.
+try:
+  GoToolsSettings.GoEnv = load_goenv()
+  print("GoTools: initialized successfully using Go environment: {0}".format(str(GoToolsSettings.GoEnv)))
+except Exception as e:
+  print("GoTools: ERROR: failed to load environment: {0}".format(str(e)))
+  raise e

--- a/gotools_util.py
+++ b/gotools_util.py
@@ -72,7 +72,9 @@ class ToolRunner():
 
   def run(self, tool, args=[], stdin=None, timeout=5):
     toolpath = None
-    searchpaths = list(map(lambda x: os.path.join(x, 'bin'), self.settings.gopath.split(':')))
+    searchpaths = list(map(lambda x: os.path.join(x, 'bin'), self.settings.gopath.split(os.pathsep)))
+    for p in self.settings.ospath.split(os.pathsep):
+      searchpaths.append(p)
     searchpaths.append(os.path.join(self.settings.goroot, 'bin'))
     searchpaths.append(self.settings.gorootbin)
 
@@ -96,9 +98,11 @@ class ToolRunner():
       env = os.environ.copy()
       env["PATH"] = self.settings.ospath
       env["GOPATH"] = self.settings.gopath
+      env["GOROOT"] = self.settings.goroot
 
       self.logger.log("  PATH:        " + env["PATH"])
       self.logger.log("  GOPATH:      " + env["GOPATH"])
+      self.logger.log("  GOROOT:      " + env["GOROOT"])
       self.logger.log("  environment: " + str(env))
       self.logger.log("  command:     " + " ".join(cmd))
 


### PR DESCRIPTION
Use smarter environment variable lookups. The new method should be portable across all shells (e.g. fish). Additionally, PATH, GOPATH, and GOROOT are all available for tool lookups and passthrough to tool execution environments.

These changes are also portable across Linux and OSX.

Fixes #97.
Supercedes #98.